### PR TITLE
*Fixed: Iteration Bug with jQuery  in the Select Box Editor

### DIFF
--- a/Resources/Public/Scripts/Inspector/Editors/FormSelectBoxEditor.js
+++ b/Resources/Public/Scripts/Inspector/Editors/FormSelectBoxEditor.js
@@ -44,9 +44,9 @@ define(
 					success: function(data) {
 						var values = [], option;
 
-						$(data).each(function(value) {
-							values.push({'value': data[value].identifier, 'label': data[value].name});
-						});
+						for (key in data) {
+                            values.push({'value': data[key].identifier, 'label': data[key].name});
+                        }
 
 						that.set('values', values);
 						that.get('options');


### PR DESCRIPTION
Hey! First of all: Thanks for that Awesome Package :)! I've just noticed there is a little Bug inside the Select Box Editor. For some reason jQuery each doesn't iterates over the returned Object. And the dropdown would not be populated with the created forms. I've just fixed this by replacing it with "native" JavaScript.
