### PR TITLE
Changed function call to retrieve the value when fieldIdentifier: is used

### DIFF
--- a/Classes/SimplyAdmire/Neos/FormBuilderBundle/Finishers/EmailFinisher.php
+++ b/Classes/SimplyAdmire/Neos/FormBuilderBundle/Finishers/EmailFinisher.php
@@ -30,8 +30,8 @@ class EmailFinisher extends \TYPO3\Form\Finishers\EmailFinisher {
 		if (substr($value, 0, 16) === 'fieldIdentifier:') {
 			$formRuntime = $this->finisherContext->getFormRuntime();
 			$field = str_replace('fieldIdentifier:', '', $value);
-			if ($formRuntime->getRequest()->hasArgument($field)) {
-				return $formRuntime->getRequest()->getArgument($field);
+			if ($formRuntime->getFormState()->getFormValue($field)) {
+				return $formRuntime->getFormState()->getFormValue($field);
 			}
 		}
 


### PR DESCRIPTION
TBH: I haven't tested this in Neos 1.X, but the the $formRuntime variable does not seem to have a property request anymore. But the field value can be retrieved from $formRuntime->getFormState()->getFormValue($field).