### PR TITLE
1 set of round brackets too many causing PHP fatal error

### DIFF
--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -2,7 +2,7 @@
 privilegeTargets:
   TYPO3\Flow\Security\Authorization\Privilege\Method\MethodPrivilege:
     TYPO3_FormBuilder_Standard:
-      matcher: 'method((TYPO3\FormBuilder\Controller\StandardController|SimplyAdmire\Neos\FormBuilderBundle\Controller\FormController)->.*Action())'
+      matcher: 'method(TYPO3\FormBuilder\Controller\StandardController|SimplyAdmire\Neos\FormBuilderBundle\Controller\FormController->.*Action())'
     TYPO3_FormBuilder_FormManager:
       matcher: 'method(TYPO3\FormBuilder\Controller\FormManagerController->.*Action())'
     TYPO3_FormBuilder_Editor:


### PR DESCRIPTION
PHP Fatal error:  Cannot override final method Doctrine\DBAL\Types\Type::__construct() in /var/www/neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/TYPO3_Flow_Persistence_Doctrine_DataTypes_JsonArrayType.php on line 235
Fatal error: Cannot override final method
Doctrine\DBAL\Types\Type::__construct() in
/var/www/neos/Data/Temporary/Development/Cache/Code/Flow_Object_Classes/TYPO3_Flow_Persistence_Doctrine_DataTypes_JsonArrayType.php on line 235
